### PR TITLE
Fix non-lowercase response header

### DIFF
--- a/lib/sugar/plugs/hot_code_reload.ex
+++ b/lib/sugar/plugs/hot_code_reload.ex
@@ -10,7 +10,7 @@ defmodule Sugar.Plugs.HotCodeReload do
       :ok ->
         location = "/" <> Enum.join conn.path_info, "/"
         conn
-          |> put_resp_header("Location", location)
+          |> put_resp_header("location", location)
           |> send_resp_if_not_sent(302, "")
       _   -> conn
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Plugs.Mixfile do
 
   def project do
     [ app: :plugs,
-      version: "0.0.4",
+      version: "0.0.5",
       elixir: "~> 1.0",
       name: "Plugs",
       deps: deps,


### PR DESCRIPTION
**Warning:** entirely untested.  Merge at your own risk (preferably after testing it, which I hope to do immediately after creating this PR).

Should resolve `Elixir.Plug.Conn.InvalidHeaderKeyFormatError`s that pop up sometimes with a message of "header key is not lowercase: Location".  Seems like Plug should be able to convert the header key to lowercase automatically, but whatever.