### PR TITLE
Add support for `:return_to` option on `Sugar.Plugs.EnsureAuthenticated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ defmodule MyApp.Router do
 end
 ```
 
+You'll also want a controller to present a login page and authenticate a user (and possibly act on `conn.params["return_to"]`; see below).
+
 ### Use
 
 Add this to a controller you want authentication on:
@@ -76,6 +78,16 @@ If your controller has some actions that don't need authentication, then you can
 * Users should be directed to your app's `/login` route if they're not currently logged in
 
 The first two can be overridden by calling the plug as `plug Sugar.Plugs.EnsureAuthenticated, repo: My.Custom.Repo, model: My.Custom.Model` (should be self-explanatory).  The third can't be changed quite yet (TODO: add that configuration option), at least not without implementing a custom handler (see below).
+
+#### `:return_to` (`:origin` or an explicit URL)
+
+One can provide a `:return_to` option, which adds a query parameter (named `return_to` by default) to signal to a login page where the user should be redirected to after logging in.  The most automatic approach would be to set this to `:origin`, like so:
+
+```elixir
+plug Sugar.Plugs.EnsureAuthenticated, return_to: :origin
+```
+
+The above reads the connection's original path and sets `conn.params["return_to"]` automatically.
 
 #### Custom Handler
 

--- a/lib/sugar/plugs/ensure_authenticated.ex
+++ b/lib/sugar/plugs/ensure_authenticated.ex
@@ -90,6 +90,9 @@ defmodule Sugar.Plugs.EnsureAuthenticated do
   defp ensure(conn, nil, opts), do: redirect(conn, destination(conn, opts))
   defp ensure(conn, user, _), do: assign(conn, :current_user, user)
 
+  defp destination(conn, %{redirect_to: redirect_to, return_to: nil}) do
+    redirect_to
+  end
   defp destination(conn, %{redirect_to: redirect_to, return_to: return_to}) do
     redirect_to <> return_to_params(conn, return_to)
   end

--- a/lib/sugar/plugs/ensure_authenticated.ex
+++ b/lib/sugar/plugs/ensure_authenticated.ex
@@ -26,7 +26,11 @@ defmodule Sugar.Plugs.EnsureAuthenticated do
     unless is_list(only) and is_list(except), do: raise ArgumentError
 
     # main pieces
-    opts = %{handler: handler, model: model, repo: repo}
+    opts = %{ handler:     handler,
+              redirect_to: redirect_to,
+              return_to:   return_to,
+              model:       model,
+              repo:        repo }
 
     # sanitize
     cond do

--- a/lib/sugar/plugs/ensure_authenticated.ex
+++ b/lib/sugar/plugs/ensure_authenticated.ex
@@ -50,7 +50,7 @@ defmodule Sugar.Plugs.EnsureAuthenticated do
 
   def verify(conn, %{only: actions} = opts) do
     if conn.private.action in actions do
-      conn |> verify(opts)
+      conn |> verify(opts |> Map.drop([:only, :except]))
     else
       conn
     end
@@ -59,7 +59,7 @@ defmodule Sugar.Plugs.EnsureAuthenticated do
     if conn.private.action in actions do
       conn
     else
-      conn |> verify(opts)
+      conn |> verify(opts |> Map.drop([:only, :except]))
     end
   end
   def verify(conn, %{repo: repo, model: model} = opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Plugs.Mixfile do
 
   def project do
     [ app: :plugs,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.0",
       name: "Plugs",
       deps: deps,


### PR DESCRIPTION
Also includes a hotfix for the `:only`/`:except` options (which triggered an infinite loop previously).